### PR TITLE
Add `-debug` flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,6 @@
+builds:
+  - binary: csp-collector
+    goos:
+      - linux
+    goarch:
+      - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,5 +2,6 @@ builds:
   - binary: csp-collector
     goos:
       - linux
+      - darwin
     goarch:
       - amd64

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -20,8 +23,27 @@ type CSPReport struct {
 	} `json:"csp-report"`
 }
 
+var (
+	Debug *log.Logger
+
+	// Flag for toggling verbose output.
+	debugFlag bool
+)
+
+func setupDebugLogger(debugHandle io.Writer) {
+	Debug = log.New(debugHandle, "[DEBUG] ", log.Lmicroseconds)
+}
+
 func main() {
-	log.Println("Starting up...")
+	setupDebugLogger(os.Stdout)
+
+	flag.BoolVar(&debugFlag, "debug", false, "Output additional logging for debugging")
+	flag.Parse()
+
+	if debugFlag {
+		Debug.Println("Starting up...")
+	}
+
 	http.HandleFunc("/", handleViolationReport)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
Sometimes you want to know what is going on under the hood without breaking
out a debugger. Other times you really don't care. To facilitate both of
these needs, I've created a `debug` logger that will handle outputting it
correctly and conditionally outputted it based on the flags at runtime.

In this PR, I'm also experimenting with [`goreleaser`](https://github.com/goreleaser/goreleaser) to handle the
distribution of packages better.