### PR TITLE
Allow `status-code` to be string or integer

### DIFF
--- a/csp_collector.go
+++ b/csp_collector.go
@@ -13,17 +13,21 @@ import (
 
 // CSPReport is the structure of the HTTP payload the system receives.
 type CSPReport struct {
-	Body struct {
-		DocumentURI        string `json:"document-uri"`
-		Referrer           string `json:"referrer"`
-		BlockedURI         string `json:"blocked-uri"`
-		ViolatedDirective  string `json:"violated-directive"`
-		EffectiveDirective string `json:"effective-directive"`
-		OriginalPolicy     string `json:"original-policy"`
-		Disposition        string `json:"disposition"`
-		ScriptSample       string `json:"script-sample"`
-		StatusCode         string `json:"status-code"`
-	} `json:"csp-report"`
+	Body CSPReportBody `json:"csp-report"`
+}
+
+// CSPReportBody contains the fields that are nested within the
+// violation report.
+type CSPReportBody struct {
+	DocumentURI        string      `json:"document-uri"`
+	Referrer           string      `json:"referrer"`
+	BlockedURI         string      `json:"blocked-uri"`
+	ViolatedDirective  string      `json:"violated-directive"`
+	EffectiveDirective string      `json:"effective-directive"`
+	OriginalPolicy     string      `json:"original-policy"`
+	Disposition        string      `json:"disposition"`
+	ScriptSample       string      `json:"script-sample"`
+	StatusCode         interface{} `json:"status-code"`
 }
 
 var (


### PR DESCRIPTION
Updates the `CSPReport` struct to accept a string or integer for the
`status-code` value due to browser inconsistencies in violation reports.

As a side note, I'm chasing up which browsers are sending strings as
CSP2 and CSP3 expect a `long` and `int` respectively.

Fixes #15