### PR TITLE
Allow comments in filter list

### DIFF
--- a/csp_collector.go
+++ b/csp_collector.go
@@ -89,12 +89,19 @@ func init() {
 	log.SetLevel(log.InfoLevel)
 }
 
-func trimEmpty(s []string) []string {
+func trimEmptyAndComments(s []string) []string {
 	var r []string
 	for _, str := range s {
-		if str != "" {
-			r = append(r, str)
+		if str == "" {
+			continue
 		}
+
+		// ignore comments
+		if strings.HasPrefix(str, "#") {
+			continue
+		}
+
+		r = append(r, str)
 	}
 	return r
 }
@@ -118,7 +125,7 @@ func main() {
 		if err != nil {
 			fmt.Printf("Error reading Blocked File list: %s", blockedURIfile)
 		}
-		ignoredBlockedURIs = trimEmpty(strings.Split(string(content), "\n"))
+		ignoredBlockedURIs = trimEmptyAndComments(strings.Split(string(content), "\n"))
 	}
 
 	if debugFlag {

--- a/csp_collector_test.go
+++ b/csp_collector_test.go
@@ -165,3 +165,28 @@ func TestHandleViolationReportMultipleTypeStatusCode(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterListProcessing(t *testing.T) {
+	// Discard the output we create from the calls here.
+	log.SetOutput(ioutil.Discard)
+
+	blockList := []string{
+		"resource://",
+		"",
+		"# comment",
+		"chrome-extension://",
+		"",
+	}
+
+	trimmed := trimEmptyAndComments(blockList)
+
+	if len(trimmed) != 2 {
+		t.Errorf("expected filter list length 2; got %v", len(trimmed))
+	}
+	if trimmed[0] != "resource://" {
+		t.Errorf("unexpected list entry; got %v", trimmed[0])
+	}
+	if trimmed[1] != "chrome-extension://" {
+		t.Errorf("unexpected list entry; got %v", trimmed[1])
+	}
+}

--- a/sample.filterlist.txt
+++ b/sample.filterlist.txt
@@ -1,3 +1,4 @@
+# hash indicates a comment
 resource://
 chromenull://
 chrome-extension://


### PR DESCRIPTION
Allow lines starting with a "#" to be treated as comments in the filter list.
Add a relevant example to the sample list.
Add a test for the functionality.