### PR TITLE
Exclude non-http documents

### DIFF
--- a/csp_collector.go
+++ b/csp_collector.go
@@ -212,5 +212,9 @@ func validateViolation(r CSPReport) error {
 		}
 	}
 
+	if !strings.HasPrefix(r.Body.DocumentURI, "http") {
+		return fmt.Errorf("document URI ('%s') is invalid", r.Body.DocumentURI)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Standard reports will include the uri of the document they're sent from. Some
browsers will get confused though and send reports for either empty or bogus
documents like "about". These are not actionable and can be excluded from
reporting.