### PR TITLE
Support injecting metadata as new field

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ $ CGO_ENABLED=0 go build csp_collector.go
 
 See the sample.filterlist.txt file as an example of the filter list in a file
 
+### Request metadata
+
+Additional information can be attached to each report by adding a `metadata`
+url parameter to each report. That value will be copied verbatim into the
+logged report.
+
+For example a report sent to `https://collector.example.com/?metadata=foobar`
+will include field `metadata` with value `foobar`.
+
 ### Output formats
 
 The output format can be controlled by passing `--output-format <type>`

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -191,6 +191,12 @@ func handleViolationReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	metadatas, got_metadata := r.URL.Query()["metadata"]
+	var metadata string
+	if got_metadata {
+		metadata = metadatas[0]
+	}
+
 	log.WithFields(log.Fields{
 		"document_uri":        report.Body.DocumentURI,
 		"referrer":            report.Body.Referrer,
@@ -201,6 +207,7 @@ func handleViolationReport(w http.ResponseWriter, r *http.Request) {
 		"disposition":         report.Body.Disposition,
 		"script_sample":       report.Body.ScriptSample,
 		"status_code":         report.Body.StatusCode,
+		"metadata":            metadata,
 	}).Info()
 }
 

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -191,9 +191,9 @@ func handleViolationReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metadatas, got_metadata := r.URL.Query()["metadata"]
+	metadatas, gotMetadata := r.URL.Query()["metadata"]
 	var metadata string
-	if got_metadata {
+	if gotMetadata {
 		metadata = metadatas[0]
 	}
 

--- a/csp_collector_test.go
+++ b/csp_collector_test.go
@@ -70,7 +70,7 @@ func TestHandlerWithMetadata(t *testing.T) {
 		log.SetOutput(&logBuffer)
 
 		url := "/?"
-		for i := 0; i < repeats; i += 1 {
+		for i := 0; i < repeats; i++ {
 			url += fmt.Sprintf("metadata=value%d&", i)
 		}
 


### PR DESCRIPTION
This allows services to add some data which can be correlated with a specific
request without trying to match specific time/url/... by hand in the logs.

Any string assigned to first `metadata` parameter will be copied verbatim to the
logged `metadata` field.