### PR TITLE
Update build script to ignore structure

### DIFF
--- a/script/build
+++ b/script/build
@@ -41,9 +41,9 @@ do
 
   printf "==> Tarballing %s\t%s\n" "$platform" "build/${output_name}.tar.gz" | expand -t 30
   if [ $GOOS = "windows" ]; then
-    tar -czf "build/${output_name}.tar.gz" "build/${output_name}.exe"
+    tar -czf "build/${output_name}.tar.gz" -C "build" "${output_name}.exe"
   else
-    tar -czf "build/${output_name}.tar.gz" "build/${output_name}"
+    tar -czf "build/${output_name}.tar.gz" -C "build" "${output_name}"
   fi
 
   if [ $? -ne 0 ]; then

--- a/script/build
+++ b/script/build
@@ -7,6 +7,9 @@ if [[ -z "$version" ]]; then
   exit 1
 fi
 
+git_sha=`git rev-parse --short HEAD`
+version_with_sha="${version}+${git_sha}"
+
 if [ -d build ]; then
   rm -rf build
 fi
@@ -27,9 +30,9 @@ do
 
 
   if [ $GOOS = "windows" ]; then
-    env GOOS=$GOOS GOARCH=$GOARCH go build -o "build/${output_name}.exe" .
+    env GOOS=$GOOS GOARCH=$GOARCH go build -o "build/${output_name}.exe" -ldflags "-X main.Rev=${version_with_sha}" .
   else
-    env GOOS=$GOOS GOARCH=$GOARCH go build -o "build/${output_name}" .
+    env GOOS=$GOOS GOARCH=$GOARCH go build -o "build/${output_name}" -ldflags "-X main.Rev=${version_with_sha}" .
   fi
   if [ $? -ne 0 ]; then
     echo "Building the binary has failed!"


### PR DESCRIPTION
Fixes the build script to only tarball the executable instead of the
build directory too.

Includes a fix to pass through `Rev` for the `-version` output (
`version + build metadata` of git sha).