### PR TITLE
Ignore the ms-appx schemas

### DIFF
--- a/csp_collector.go
+++ b/csp_collector.go
@@ -69,6 +69,8 @@ var (
 		"chromeinvokeimmediate://",
 		"mbinit://",
 		"opera://",
+		"ms-appx://",
+		"ms-appx-web://",
 		"localhost",
 		"127.0.0.1",
 		"none://",

--- a/sample.filterlist.txt
+++ b/sample.filterlist.txt
@@ -12,6 +12,8 @@ chromeinvoke://
 chromeinvokeimmediate://
 mbinit://
 opera://
+ms-appx://
+ms-appx-web://
 localhost
 127.0.0.1
 none://


### PR DESCRIPTION
These are used for the universal ms apps.
Ref: https://docs.microsoft.com/en-us/windows/uwp/app-resources/uri-schemes#ms-appx-and-ms-appx-web