### PR TITLE
Add flag to change healthcheck url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ CGO_ENABLED=0 go build csp_collector.go
 |debug  |Runs in debug mode producing more verbose output|
 |port	|Port to run on, default 8080|
 |filter-file|Reads the blocked URI filter list from the specified file. Note one filter per line|
+|health-check-path|Sets path for health checkers to use, default \/_healthcheck|
 
 
 See the sample.filterlist.txt file as an example of the filter list in a file

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -43,6 +43,9 @@ var (
 	// Flag for toggling output format.
 	outputFormat string
 
+	// Flag for health check url.
+	healthCheckPath = "/_healthcheck"
+
 	// Shared defaults for the logger output. This ensures that we are
 	// using the same keys for the `FieldKey` values across both formatters.
 	logFieldMapDefaults = log.FieldMap{
@@ -114,6 +117,7 @@ func main() {
 	flag.StringVar(&outputFormat, "output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
 	flag.StringVar(&blockedURIfile, "filter-file", "", "Blocked URI Filter file")
 	flag.IntVar(&listenPort, "port", 8080, "Port to listen on")
+	flag.StringVar(&healthCheckPath, "health-check-path", healthCheckPath, "Health checker path")
 
 	flag.Parse()
 
@@ -162,7 +166,7 @@ func main() {
 }
 
 func handleViolationReport(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "GET" && r.URL.Path == "/_healthcheck" {
+	if r.Method == "GET" && r.URL.Path == healthCheckPath {
 		w.WriteHeader(http.StatusOK)
 		return
 	}


### PR DESCRIPTION
Health check urls aren't really standardized - many use healthz but just as many use completely custom endpoints.
Having a command line option to change this url adds some flexibility when deploying this application without provided helm chart.