### PR TITLE
Fix selector in service: use helper function

### DIFF
--- a/deployments/kubernetes-helm/templates/service.yaml
+++ b/deployments/kubernetes-helm/templates/service.yaml
@@ -16,5 +16,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ template "csp-collector.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "csp-collector.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
The selectors aren't referencing the deployment, using the intended helper should do the trick