### PR TITLE
Allow setting a securityContext

### DIFF
--- a/deployments/kubernetes-helm/templates/deployment.yaml
+++ b/deployments/kubernetes-helm/templates/deployment.yaml
@@ -67,3 +67,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}


### PR DESCRIPTION
Useful when you want to explicitly set the 'run as user', for example.