### PR TITLE
Bump ingress apiVersion (kubernetes v1.19+)

### DIFF
--- a/deployments/kubernetes-helm/templates/ingress.yaml
+++ b/deployments/kubernetes-helm/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "csp-collector.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,8 +29,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
extensions/v1beta1 is removed in v1.22, so suggesting to change it to networking.k8s.io/v1 which is supported from v1.19