### PR TITLE
Log more interesting information

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17, 1.18, 1.19]
+        go-version: [1.18, 1.19]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS build
+FROM golang:1.19-alpine AS build
 COPY . /go/src/jacobbednarz/go-csp-collector
 WORKDIR /go/src/jacobbednarz/go-csp-collector
 RUN set -ex \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ $ CGO_ENABLED=0 go build csp_collector.go
 |port	|Port to run on, default 8080|
 |filter-file|Reads the blocked URI filter list from the specified file. Note one filter per line|
 |health-check-path|Sets path for health checkers to use, default \/_healthcheck|
+|log-client-ip|Include a field in the log with the IP delivering the report, or the value of the `X-Forwarded-For` header, if present.|
+|log-truncated-client-ip|Include a field in the log with the truncated IP (to /24 for IPv4, /64 for IPv6) delivering the report, or the value of the `X-Forwarded-For` header, if present. Conflicts with `log-client-ip`.
+|truncated-query-fragment|Remove all query strings and fragments (if set) from all URLs transmitted by the client|
+|query-params-metadata|Log all query parameters of the report URL as a map in the `metadata` field|
 
 
 See the sample.filterlist.txt file as an example of the filter list in a file
@@ -53,6 +57,11 @@ logged report.
 
 For example a report sent to `https://collector.example.com/?metadata=foobar`
 will include field `metadata` with value `foobar`.
+
+If `query-params-metadata` is set, instead all query parameters are logged as a
+map, e.g. `https://collector.example.com/?env=production&mode=enforce` will
+result in `"metadata": {"env": "production", "mode": "enforce"}` in JSON
+format, and `metadata="map[env:production mode:enforce]"` in default format.
 
 ### Output formats
 

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -37,9 +37,6 @@ var (
 	// was created at.
 	Rev = "dev"
 
-	// Flag for toggling verbose output.
-	debugFlag bool
-
 	// Flag for toggling output format.
 	outputFormat string
 
@@ -113,7 +110,7 @@ func trimEmptyAndComments(s []string) []string {
 
 func main() {
 	version := flag.Bool("version", false, "Display the version")
-	flag.BoolVar(&debugFlag, "debug", false, "Output additional logging for debugging")
+	debugFlag := flag.Bool("debug", false, "Output additional logging for debugging")
 	flag.StringVar(&outputFormat, "output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
 	flag.StringVar(&blockedURIfile, "filter-file", "", "Blocked URI Filter file")
 	flag.IntVar(&listenPort, "port", 8080, "Port to listen on")
@@ -126,7 +123,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if debugFlag {
+	if *debugFlag {
 		log.SetLevel(log.DebugLevel)
 	}
 

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -214,6 +214,7 @@ func (vrh *violationReportHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		"script_sample":       report.Body.ScriptSample,
 		"status_code":         report.Body.StatusCode,
 		"metadata":            metadata,
+		"path":                r.URL.Path,
 	}).Info()
 }
 

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -126,14 +126,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	if blockedURIfile != "" {
-		content, err := ioutil.ReadFile(blockedURIfile)
-		if err != nil {
-			fmt.Printf("Error reading Blocked File list: %s", blockedURIfile)
-		}
-		ignoredBlockedURIs = trimEmptyAndComments(strings.Split(string(content), "\n"))
-	}
-
 	if debugFlag {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -155,9 +147,16 @@ func main() {
 	log.Debug("Starting up...")
 	if blockedURIfile != "" {
 		log.Debugf("Using Filter list from file at: %s\n", blockedURIfile)
+
+		content, err := ioutil.ReadFile(blockedURIfile)
+		if err != nil {
+			log.Fatalf("Error reading Blocked File list: %s", blockedURIfile)
+		}
+		ignoredBlockedURIs = trimEmptyAndComments(strings.Split(string(content), "\n"))
 	} else {
 		log.Debug("Using Filter list from internal list")
 	}
+
 	log.Debugf("Blocked URI List: %s", ignoredBlockedURIs)
 	log.Debugf("Listening on TCP Port: %s", strconv.Itoa(listenPort))
 
@@ -185,7 +184,7 @@ func handleViolationReport(w http.ResponseWriter, r *http.Request) {
 	err := decoder.Decode(&report)
 	if err != nil {
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		log.Debug(fmt.Sprintf("Unable to decode invalid JSON payload: %s", err))
+		log.Debugf("Unable to decode invalid JSON payload: %s", err)
 		return
 	}
 	defer r.Body.Close()
@@ -193,7 +192,7 @@ func handleViolationReport(w http.ResponseWriter, r *http.Request) {
 	reportValidation := validateViolation(report)
 	if reportValidation != nil {
 		http.Error(w, reportValidation.Error(), http.StatusBadRequest)
-		log.Debug(fmt.Sprintf("Received invalid payload: %s", reportValidation.Error()))
+		log.Debugf("Received invalid payload: %s", reportValidation.Error())
 		return
 	}
 

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -48,9 +48,6 @@ var (
 		log.FieldKeyMsg:   "message",
 	}
 
-	// Path to file which has blocked URI's per line.
-	blockedURIfile string
-
 	// Default URI Filter list.
 	ignoredBlockedURIs = []string{
 		"resource://",
@@ -109,7 +106,7 @@ func main() {
 	version := flag.Bool("version", false, "Display the version")
 	debugFlag := flag.Bool("debug", false, "Output additional logging for debugging")
 	outputFormat := flag.String("output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
-	flag.StringVar(&blockedURIfile, "filter-file", "", "Blocked URI Filter file")
+	blockedURIFile := flag.String("filter-file", "", "Blocked URI Filter file")
 	flag.IntVar(&listenPort, "port", 8080, "Port to listen on")
 	flag.StringVar(&healthCheckPath, "health-check-path", healthCheckPath, "Health checker path")
 
@@ -139,12 +136,12 @@ func main() {
 	}
 
 	log.Debug("Starting up...")
-	if blockedURIfile != "" {
-		log.Debugf("Using Filter list from file at: %s\n", blockedURIfile)
+	if *blockedURIFile != "" {
+		log.Debugf("Using Filter list from file at: %s\n", *blockedURIFile)
 
-		content, err := ioutil.ReadFile(blockedURIfile)
+		content, err := ioutil.ReadFile(*blockedURIFile)
 		if err != nil {
-			log.Fatalf("Error reading Blocked File list: %s", blockedURIfile)
+			log.Fatalf("Error reading Blocked File list: %s", *blockedURIFile)
 		}
 		ignoredBlockedURIs = trimEmptyAndComments(strings.Split(string(content), "\n"))
 	} else {

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -32,13 +32,15 @@ type CSPReportBody struct {
 	StatusCode         interface{} `json:"status-code"`
 }
 
+const (
+	// Default health check url.
+	defaultHealthCheckPath = "/_healthcheck"
+)
+
 var (
 	// Rev is set at build time and holds the revision that the package
 	// was created at.
 	Rev = "dev"
-
-	// Flag for health check url.
-	healthCheckPath = "/_healthcheck"
 
 	// Shared defaults for the logger output. This ensures that we are
 	// using the same keys for the `FieldKey` values across both formatters.
@@ -105,7 +107,7 @@ func main() {
 	outputFormat := flag.String("output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
 	blockedURIFile := flag.String("filter-file", "", "Blocked URI Filter file")
 	listenPort := flag.Int("port", 8080, "Port to listen on")
-	flag.StringVar(&healthCheckPath, "health-check-path", healthCheckPath, "Health checker path")
+	healthCheckPath := flag.String("health-check-path", defaultHealthCheckPath, "Health checker path")
 
 	flag.Parse()
 
@@ -148,7 +150,7 @@ func main() {
 	log.Debugf("Blocked URI List: %s", ignoredBlockedURIs)
 	log.Debugf("Listening on TCP Port: %s", strconv.Itoa(*listenPort))
 
-	http.HandleFunc(healthCheckPath, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(*healthCheckPath, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -160,16 +160,20 @@ func main() {
 	log.Debugf("Blocked URI List: %s", ignoredBlockedURIs)
 	log.Debugf("Listening on TCP Port: %s", strconv.Itoa(listenPort))
 
+	http.HandleFunc(healthCheckPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
 	http.HandleFunc("/", handleViolationReport)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(listenPort)), nil))
 }
 
 func handleViolationReport(w http.ResponseWriter, r *http.Request) {
-	if r.Method == "GET" && r.URL.Path == healthCheckPath {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		log.WithFields(log.Fields{

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/netip"
 	"os"
@@ -146,7 +145,7 @@ func main() {
 	if *blockedURIFile != "" {
 		log.Debugf("Using Filter list from file at: %s\n", *blockedURIFile)
 
-		content, err := ioutil.ReadFile(*blockedURIFile)
+		content, err := os.ReadFile(*blockedURIFile)
 		if err != nil {
 			log.Fatalf("Error reading Blocked File list: %s", *blockedURIFile)
 		}

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -37,9 +37,6 @@ var (
 	// was created at.
 	Rev = "dev"
 
-	// Flag for toggling output format.
-	outputFormat string
-
 	// Flag for health check url.
 	healthCheckPath = "/_healthcheck"
 
@@ -111,7 +108,7 @@ func trimEmptyAndComments(s []string) []string {
 func main() {
 	version := flag.Bool("version", false, "Display the version")
 	debugFlag := flag.Bool("debug", false, "Output additional logging for debugging")
-	flag.StringVar(&outputFormat, "output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
+	outputFormat := flag.String("output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
 	flag.StringVar(&blockedURIfile, "filter-file", "", "Blocked URI Filter file")
 	flag.IntVar(&listenPort, "port", 8080, "Port to listen on")
 	flag.StringVar(&healthCheckPath, "health-check-path", healthCheckPath, "Health checker path")
@@ -127,7 +124,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	if outputFormat == "json" {
+	if *outputFormat == "json" {
 		log.SetFormatter(&log.JSONFormatter{
 			FieldMap: logFieldMapDefaults,
 		})

--- a/csp_collector.go
+++ b/csp_collector.go
@@ -75,9 +75,6 @@ var (
 		"nativebaiduhd://adblock",
 		"bdvideo://error",
 	}
-
-	// TCP Port to listen on.
-	listenPort int
 )
 
 func init() {
@@ -107,7 +104,7 @@ func main() {
 	debugFlag := flag.Bool("debug", false, "Output additional logging for debugging")
 	outputFormat := flag.String("output-format", "text", "Define how the violation reports are formatted for output.\nDefaults to 'text'. Valid options are 'text' or 'json'")
 	blockedURIFile := flag.String("filter-file", "", "Blocked URI Filter file")
-	flag.IntVar(&listenPort, "port", 8080, "Port to listen on")
+	listenPort := flag.Int("port", 8080, "Port to listen on")
 	flag.StringVar(&healthCheckPath, "health-check-path", healthCheckPath, "Health checker path")
 
 	flag.Parse()
@@ -149,7 +146,7 @@ func main() {
 	}
 
 	log.Debugf("Blocked URI List: %s", ignoredBlockedURIs)
-	log.Debugf("Listening on TCP Port: %s", strconv.Itoa(listenPort))
+	log.Debugf("Listening on TCP Port: %s", strconv.Itoa(*listenPort))
 
 	http.HandleFunc(healthCheckPath, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -161,7 +158,7 @@ func main() {
 	})
 
 	http.HandleFunc("/", handleViolationReport)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(listenPort)), nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(*listenPort)), nil))
 }
 
 func handleViolationReport(w http.ResponseWriter, r *http.Request) {

--- a/csp_collector_test.go
+++ b/csp_collector_test.go
@@ -15,7 +15,8 @@ import (
 
 var (
 	defaultViolationReportHandler = violationReportHandler{
-		blockedURIs: defaultIgnoredBlockedURIs,
+		blockedURIs:                 defaultIgnoredBlockedURIs,
+		truncateQueryStringFragment: false,
 	}
 )
 
@@ -274,5 +275,31 @@ func TestLogsPath(t *testing.T) {
 	log := logBuffer.String()
 	if !strings.Contains(log, "path=/deep/link") {
 		t.Fatalf("Logged result should contain path value in '%s'", log)
+	}
+}
+
+func TestTruncateQueryStringFragment(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		original string
+		expected string
+	}{
+		{"http://localhost.com/?test#anchor", "http://localhost.com/"},
+		{"http://example.invalid", "http://example.invalid"},
+		{"http://example.invalid#a", "http://example.invalid"},
+		{"http://example.invalid?a", "http://example.invalid"},
+		{"http://example.invalid#b?a", "http://example.invalid"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.original, func(t *testing.T) {
+			t.Parallel()
+			actual := truncateQueryStringFragment(tc.original)
+			if actual != tc.expected {
+				t.Errorf("truncating '%s' yielded '%s', expected '%s'", tc.original, actual, tc.expected)
+			}
+		})
 	}
 }

--- a/csp_collector_test.go
+++ b/csp_collector_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -200,7 +200,7 @@ func TestValidateViolationWithValidBlockedURIs(t *testing.T) {
 }
 
 func TestValidateNonHttpDocumentURI(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	report := CSPReport{Body: CSPReportBody{
 		BlockedURI:  "http://example.com/",
@@ -215,7 +215,7 @@ func TestValidateNonHttpDocumentURI(t *testing.T) {
 
 func TestHandleViolationReportMultipleTypeStatusCode(t *testing.T) {
 	// Discard the output we create from the calls here.
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	statusCodeValues := []interface{}{"200", 200}
 
@@ -253,7 +253,7 @@ func TestHandleViolationReportMultipleTypeStatusCode(t *testing.T) {
 
 func TestFilterListProcessing(t *testing.T) {
 	// Discard the output we create from the calls here.
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	blockList := []string{
 		"resource://",

--- a/csp_collector_test.go
+++ b/csp_collector_test.go
@@ -38,23 +38,6 @@ func TestHandlerForDisallowedMethods(t *testing.T) {
 	}
 }
 
-func TestHandlerForAllowingHealthcheck(t *testing.T) {
-	request, err := http.NewRequest("GET", "/_healthcheck", nil)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
-	recorder := httptest.NewRecorder()
-
-	handleViolationReport(recorder, request)
-
-	response := recorder.Result()
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		t.Errorf("expected HTTP status %v; got %v", http.StatusOK, response.StatusCode)
-	}
-}
-
 func TestHandlerWithMetadata(t *testing.T) {
 	csp := CSPReport{
 		CSPReportBody{

--- a/csp_collector_test.go
+++ b/csp_collector_test.go
@@ -13,12 +13,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	defaultViolationReportHandler = violationReportHandler{
-		blockedURIs:                 defaultIgnoredBlockedURIs,
-		truncateQueryStringFragment: false,
-	}
-)
+var defaultViolationReportHandler = violationReportHandler{
+	blockedURIs:                 defaultIgnoredBlockedURIs,
+	truncateQueryStringFragment: false,
+}
 
 func TestHandlerForDisallowedMethods(t *testing.T) {
 	disallowedMethods := []string{"GET", "DELETE", "PUT", "TRACE", "PATCH"}
@@ -120,7 +118,7 @@ func TestValidateViolationWithInvalidBlockedURIs(t *testing.T) {
 		testName := strings.Replace(blockedURI, "://", "", -1)
 
 		t.Run(testName, func(t *testing.T) {
-			var rawReport = []byte(fmt.Sprintf(`{
+			rawReport := []byte(fmt.Sprintf(`{
 				"csp-report": {
 					"document-uri": "https://example.com",
 					"blocked-uri": "%s"
@@ -146,7 +144,7 @@ func TestValidateViolationWithInvalidBlockedURIs(t *testing.T) {
 }
 
 func TestValidateViolationWithValidBlockedURIs(t *testing.T) {
-	var rawReport = []byte(`{
+	rawReport := []byte(`{
 		"csp-report": {
 			"document-uri": "https://example.com",
 			"blocked-uri": "https://google.com/example.css"


### PR DESCRIPTION
For our use case, we want do log additional information about a CSP report.

This change should be backwards-compatible:
* The `path` field is new, but in structured logging and in JSON additional fields should not be a problem.
* Client IP logging is disabled by default, as client IP is considerered sensitive data. Logging it should be opt-in.
* In certain use cases, the query string or the fragment part (if transmitted by the browser) might contain sensitive data, which might no be needed to act on the report. Thus, it shouldn't be logged at all.