### PR TITLE
Fix Dockerfile to build binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/jacobbednarz/go-csp-collector
 RUN set -ex \
   && apk add --no-cache git \
   && go get -d ./... \
-  && go build csp_collector.go
+  && go build -o csp_collector main.go
 
 FROM alpine:3.16
 LABEL maintainer="https://github.com/jacobbednarz/go-csp-collector"


### PR DESCRIPTION
Thanks for this great project!  I started putting it in our app and when I pulled it down, I wasn't able to build the Dockerfile:

```
❯ docker build .
[+] Building 5.4s (10/13)
 => [internal] load build definition from Dockerfile                                                        0.0s
 => => transferring dockerfile: 37B                                                                         0.0s
 => [internal] load .dockerignore                                                                           0.0s
 => => transferring context: 34B                                                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:3.16                                              1.1s
 => [internal] load metadata for docker.io/library/golang:1.19-alpine                                       1.1s
 => [internal] load build context                                                                           0.0s
 => => transferring context: 4.56kB                                                                         0.0s
 => [build 1/4] FROM docker.io/library/golang:1.19-alpine@sha256:d171aa333fb386089206252503bc6ab545072670e  0.0s
 => [stage-1 1/4] FROM docker.io/library/alpine:3.16@sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca  0.0s
 => CACHED [build 2/4] COPY . /go/src/jacobbednarz/go-csp-collector                                         0.0s
 => CACHED [build 3/4] WORKDIR /go/src/jacobbednarz/go-csp-collector                                        0.0s
 => ERROR [build 4/4] RUN set -ex   && apk add --no-cache git   && go get -d ./...   && go build csp_colle  4.2s
------
 > [build 4/4] RUN set -ex   && apk add --no-cache git   && go get -d ./...   && go build csp_collector.go:
#10 0.187 + apk add --no-cache git
#10 0.191 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz
#10 1.097 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/aarch64/APKINDEX.tar.gz
#10 1.681 (1/6) Installing brotli-libs (1.0.9-r6)
#10 1.704 (2/6) Installing nghttp2-libs (1.47.0-r0)
#10 1.718 (3/6) Installing libcurl (7.83.1-r4)
#10 2.093 (4/6) Installing expat (2.5.0-r0)
#10 2.104 (5/6) Installing pcre2 (10.40-r0)
#10 2.123 (6/6) Installing git (2.36.3-r0)
#10 2.575 Executing busybox-1.35.0-r17.trigger
#10 2.583 OK: 20 MiB in 21 packages
#10 2.606 + go get -d ./...
#10 2.974 go: downloading github.com/gorilla/mux v1.8.0
#10 2.978 go: downloading github.com/sirupsen/logrus v1.9.0
#10 3.070 go: downloading golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
#10 3.984 + go build csp_collector.go
#10 3.989 no required module provides package csp_collector.go; to add it:
#10 3.989 	go get csp_collector.go
------
executor failed running [/bin/sh -c set -ex   && apk add --no-cache git   && go get -d ./...   && go build csp_collector.go]: exit code: 1
```

It seems like something must have moved around, so this small change gets the Dockerfile building.