### PR TITLE
Add arm64 targets for Linux and Darwin

### DIFF
--- a/script/build
+++ b/script/build
@@ -15,7 +15,7 @@ if [ -d build ]; then
 fi
 mkdir -p build
 
-platforms=("windows/amd64" "linux/amd64" "darwin/amd64")
+platforms=("windows/amd64" "linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64")
 
 echo "==> Build started for v${version}"
 


### PR DESCRIPTION
Hey, thanks for merging #75 so quickly!  As I'm continuing getting this setup for us, we'd love ARM builds for our developer machines.  Is this an addition that you're interested in?  I saw that you had `script/build` setup in a way that made this trivial to add, but I suspect there might be other considerations here too.

Thoughts on this change and including ARM builds with the binary releases?