### PR TITLE
update chart to reflect current standards

### DIFF
--- a/deployments/kubernetes-helm/templates/_helpers.tpl
+++ b/deployments/kubernetes-helm/templates/_helpers.tpl
@@ -48,3 +48,13 @@ app.kubernetes.io/name: {{ include "csp-collector.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "csp-collector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "csp-collector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deployments/kubernetes-helm/templates/deployment.yaml
+++ b/deployments/kubernetes-helm/templates/deployment.yaml
@@ -6,20 +6,35 @@ metadata:
     {{- include "csp-collector.labels" . | nindent 4 }}
     checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum | trunc 63 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "csp-collector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum | trunc 63 }}
       labels:
         {{- include "csp-collector.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "csp-collector.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           - name: config-volume

--- a/deployments/kubernetes-helm/templates/hpa.yaml
+++ b/deployments/kubernetes-helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "csp-collector.fullname" . }}
+  labels:
+    {{- include "csp-collector.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "csp-collector.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployments/kubernetes-helm/templates/serviceaccount.yaml
+++ b/deployments/kubernetes-helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "csp-collector.serviceAccountName" . }}
+  labels:
+    {{- include "csp-collector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deployments/kubernetes-helm/values.yaml
+++ b/deployments/kubernetes-helm/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: latest
   pullPolicy: Always
 
+imagePullSecrets: []
+
 service:
   type: ClusterIP
   port: 8080
@@ -36,6 +38,13 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -53,3 +62,29 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+
+
+securityContext: {}
+  # fsGroup: 2000


### PR DESCRIPTION
Hi, I needed a way to configure imagePullSecrets and securityContext related stuff and ended up updating the entire chart to fit what's generated nowadays with helm create. 

This adds a ServiceAccount, HPA and some options to further configure the Deployment, this could be split up into multiple PRs if needed.

Cheers