### PR TITLE
Build and push multi-arch docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,87 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "multi-arch-builds"
+
+env:
+  REGISTRY_IMAGE: schmitze333/go-csp-collector
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}          

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,12 +1,12 @@
-name: ci
+name: build-image
 
 on:
   push:
-    branches:
-      - "multi-arch-builds"
+    tags:
+      - "v*"
 
 env:
-  REGISTRY_IMAGE: schmitze333/go-csp-collector
+  REGISTRY_IMAGE: jacobbednarz/go-csp-collector
 
 jobs:
   build:


### PR DESCRIPTION
Automate the build and provisioning of docker images to the `jacobbednarz/go-csp-collector` docker hub repo.

As discussed in https://github.com/jacobbednarz/go-csp-collector/issues/90, a new multi-arch image is now built when a new release is done (or a git tag is pushed manually). 

For this to work two conditions have to be fulfilled:

1. As already mentioned in the issue, the two repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` have to be present for the action.
2. A release Github release has to be based on a tag (or a corresponding tag has to be pushed manually).

Open for any suggestions/improvements.