### PR TITLE
helm-chart: fix format for default image tag

### DIFF
--- a/deployments/kubernetes-helm/templates/deployment.yaml
+++ b/deployments/kubernetes-helm/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
Images in Docker Hub are tagged like this: `v0.0.22` (https://hub.docker.com/r/jacobbednarz/go-csp-collector/tags).

The Chart AppVersion is set to: `0.0.22`.