### PR TITLE
feat(helm): add custom.extraArgs for unexposed collector flags

### DIFF
--- a/deployments/kubernetes-helm/README.md
+++ b/deployments/kubernetes-helm/README.md
@@ -63,5 +63,25 @@ ingress:
 | `custom.debug`              | Logs in debug mode                        | `false`                                                 |
 | `custom.filterlist`         | Name of file within the configMaps dir for custom filters| `false` Uses list compiled into the app  |
 | `custom.jsonOutput`         | Log entries as json objects, use `false` for plain text  | `true`                                   |
+| `custom.extraArgs`          | Extra CLI args appended to the container args, one list entry per argv element| `[]`                |
+
+### Extra CLI arguments
+
+Collector flags that the chart does not expose as a value can be passed
+through `custom.extraArgs`. Each list entry becomes one argument, so a flag
+that takes a value is either two entries or a single `--flag=value`:
+
+```yaml
+custom:
+  extraArgs:
+    - "--log-client-ip"
+    - "--truncate-query-fragment"
+    - "--health-check-path=/healthz"
+    - "--filter-domains-file"
+    - "/configs/domainlist.txt"
+```
+
+These are appended after the flags rendered from the values above. Run
+`csp_collector --help` (or see the project README) for the full flag list.
 
 [1]: https://github.com/jacobbednarz/go-csp-collector/tree/master/deployments/kubernetes-helm/values.yaml

--- a/deployments/kubernetes-helm/README.md
+++ b/deployments/kubernetes-helm/README.md
@@ -63,25 +63,11 @@ ingress:
 | `custom.debug`              | Logs in debug mode                        | `false`                                                 |
 | `custom.filterlist`         | Name of file within the configMaps dir for custom filters| `false` Uses list compiled into the app  |
 | `custom.jsonOutput`         | Log entries as json objects, use `false` for plain text  | `true`                                   |
-| `custom.extraArgs`          | Extra CLI args appended to the container args, one list entry per argv element| `[]`                |
-
-### Extra CLI arguments
-
-Collector flags that the chart does not expose as a value can be passed
-through `custom.extraArgs`. Each list entry becomes one argument, so a flag
-that takes a value is either two entries or a single `--flag=value`:
-
-```yaml
-custom:
-  extraArgs:
-    - "--log-client-ip"
-    - "--truncate-query-fragment"
-    - "--health-check-path=/healthz"
-    - "--filter-domains-file"
-    - "/configs/domainlist.txt"
-```
-
-These are appended after the flags rendered from the values above. Run
-`csp_collector --help` (or see the project README) for the full flag list.
+| `custom.filterDomainsFile`  | Name of file within the configMaps dir for custom domain filtering. `false` disables it. | `false` |
+| `custom.truncateQueryFragment` | Truncate query string and fragment from logged URLs to reduce risk of leaking sensitive data. | `false` |
+| `custom.logClientIP`        | Log the (full) reporting client IP address with each report. | `false` |
+| `custom.logTruncatedClientIP` | Log the truncated reporting client IP address (IPv4 /24, IPv6 /64). | `false` |
+| `custom.queryParamsMetadata` | Write report URI query parameters as a JSON object under the `metadata` field instead of a single string. | `false` |
+| `custom.healthCheckPath`    | Override the default `/_healthcheck` endpoint path. Empty keeps the collector default. | `""` |
 
 [1]: https://github.com/jacobbednarz/go-csp-collector/tree/master/deployments/kubernetes-helm/values.yaml

--- a/deployments/kubernetes-helm/templates/deployment.yaml
+++ b/deployments/kubernetes-helm/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - "--metrics-port"
             - {{ .Values.metrics.port | quote }}
           {{- end }}
+          {{- range .Values.custom.extraArgs }}
+            - {{ . | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/deployments/kubernetes-helm/templates/deployment.yaml
+++ b/deployments/kubernetes-helm/templates/deployment.yaml
@@ -66,8 +66,25 @@ spec:
             - "--metrics-port"
             - {{ .Values.metrics.port | quote }}
           {{- end }}
-          {{- range .Values.custom.extraArgs }}
-            - {{ . | quote }}
+          {{- if .Values.custom.filterDomainsFile }}
+            - "--filter-domains-file"
+            - "/configs/{{- .Values.custom.filterDomainsFile -}}"
+          {{- end }}
+          {{- if .Values.custom.healthCheckPath }}
+            - "--health-check-path"
+            - {{ .Values.custom.healthCheckPath | quote }}
+          {{- end }}
+          {{- if .Values.custom.truncateQueryFragment }}
+            - "--truncate-query-fragment"
+          {{- end }}
+          {{- if .Values.custom.logClientIP }}
+            - "--log-client-ip"
+          {{- end }}
+          {{- if .Values.custom.logTruncatedClientIP }}
+            - "--log-truncated-client-ip"
+          {{- end }}
+          {{- if .Values.custom.queryParamsMetadata }}
+            - "--query-params-metadata"
           {{- end }}
           ports:
             - name: http

--- a/deployments/kubernetes-helm/values.yaml
+++ b/deployments/kubernetes-helm/values.yaml
@@ -34,6 +34,16 @@ custom:
   # Log Json Output
   jsonOutput: true
   debug: false
+  # extraArgs are appended verbatim to the container args, after the flags
+  # managed by the values above. One list entry per argv element, so a flag
+  # that takes a value is either two entries or a single "--flag=value". Use
+  # this for collector flags the chart does not expose yet. Eg:
+  # extraArgs:
+  #   - "--log-client-ip"
+  #   - "--health-check-path=/healthz"
+  #   - "--filter-domains-file"
+  #   - "/configs/domainlist.txt"
+  extraArgs: []
 
 ingress:
   enabled: false

--- a/deployments/kubernetes-helm/values.yaml
+++ b/deployments/kubernetes-helm/values.yaml
@@ -31,19 +31,28 @@ custom:
   #  or the path within the configMaps directly without any prefixes. Eg
   # filterlist: 'filterlist.txt'
   filterlist: false
+  # filterDomainsFile is either false, to disable domain filtering,
+  #  or the path within the configMaps directly without any prefixes. Eg
+  # filterDomainsFile: 'domainlist.txt'
+  filterDomainsFile: false
   # Log Json Output
   jsonOutput: true
   debug: false
-  # extraArgs are appended verbatim to the container args, after the flags
-  # managed by the values above. One list entry per argv element, so a flag
-  # that takes a value is either two entries or a single "--flag=value". Use
-  # this for collector flags the chart does not expose yet. Eg:
-  # extraArgs:
-  #   - "--log-client-ip"
-  #   - "--health-check-path=/healthz"
-  #   - "--filter-domains-file"
-  #   - "/configs/domainlist.txt"
-  extraArgs: []
+  # Truncate query string and fragment from document-uri, referrer and
+  # blocked-uri before logging (reduces risk of logging sensitive data).
+  truncateQueryFragment: false
+  # Log the (full) reporting client IP address with each report.
+  logClientIP: false
+  # Log the truncated reporting client IP address (IPv4 /24, IPv6 /64).
+  # If both logClientIP and logTruncatedClientIP are enabled, the truncated
+  # value wins because the collector writes it last.
+  logTruncatedClientIP: false
+  # Write query parameters of the report URI as a JSON object under the
+  # metadata field instead of as a single metadata string.
+  queryParamsMetadata: false
+  # Override the default /_healthcheck endpoint path. Empty (default) keeps
+  # the collector default.
+  healthCheckPath: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
The chart renders the container `args` from a fixed set of values (`custom.jsonOutput`, `custom.filterlist`, `custom.debug`, `metrics.*`). Additional  flags (e.g., `--log-client-ip`, `--filter-domains-file`, etc) can't be set without forking the chart or patching the output.

This PR adds a `custom.extraArgs` list appended  to the container args after the flags managed by the existing values. One list entry per argv element:

```yaml
custom:
  extraArgs:
    - "--log-client-ip"
    - "--health-check-path=/healthz"
    - "--filter-domains-file"
    - "/configs/domainlist.txt"
```

### Backwards compatibility

`extraArgs` defaults to `[]`, and range over an empty or nil list renders nothing. 

