### PR TITLE
Revert "helm-chart: fix format for default image tag"

### DIFF
--- a/deployments/kubernetes-helm/templates/deployment.yaml
+++ b/deployments/kubernetes-helm/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
Reverts jacobbednarz/go-csp-collector#154

The new release process _does_ in fact tag images in the format `0.0.x` instead of `v0.0.x` as expected by this PR. So revert to old behaviour :)